### PR TITLE
Update to PHPUnit 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 vendor/
 composer.lock
+.phpunit.result.cache
 scratchpad.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: php
 
 php:
-  - 7
-  - 7.1
-  - 7.2
   - 7.3
   - 7.4
   - nightly

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": ">=7.3",
         "ext-ctype": "*",
         "ext-intl": "*",
         "pcrov/unicode": "^0.1",
         "psr/http-message": "^1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^9.4",
         "nst/jsontestsuite": "^1"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Tests">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Tests">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This is a streaming pull parser - like [XMLReader](http://php.net/xmlreader) but
 
 ## Requirements
 
-PHP 7 with the Ctype and Intl extensions.
+PHP 7.3 or higher with the Ctype and Intl extensions.
 
 ## Installation
 

--- a/test/JsonReaderTest.php
+++ b/test/JsonReaderTest.php
@@ -14,7 +14,7 @@ class JsonReaderTest extends TestCase
     /** @var \Traversable */
     protected $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->reader = new JsonReader();
         $this->parser = new class implements Parser

--- a/test/Parser/JsonParserTest.php
+++ b/test/Parser/JsonParserTest.php
@@ -290,7 +290,7 @@ class JsonParserTest extends TestCase
         ];
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tokenizer = new class() implements Tokenizer
         {


### PR DESCRIPTION
This drops support for PHP 7.2 and under, and enables support for the upcoming PHP 8.