### PR TITLE
Support for PHP8.4

### DIFF
--- a/src/JsonReader.php
+++ b/src/JsonReader.php
@@ -177,7 +177,7 @@ class JsonReader
     /**
      * @throws Exception
      */
-    public function next(string $target = null): bool
+    public function next(?string $target = null): bool
     {
         if ($this->parser === null) {
             throw new Exception("Load data before trying to read.");
@@ -220,7 +220,7 @@ class JsonReader
     /**
      * @throws Exception
      */
-    public function read(string $target = null): bool
+    public function read(?string $target = null): bool
     {
         if ($this->parser === null) {
             throw new Exception("Load data before trying to read.");


### PR DESCRIPTION
This PR will fix deprecation warnings when run using php8.4

```
vendor/pcrov/jsonreader/src/JsonReader.php:176
pcrov\JsonReader\JsonReader::next(): Implicitly marking parameter $target as nullable is deprecated, the explicit nullable type must be used instead
```